### PR TITLE
enabled title to wrap

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -23,8 +23,22 @@
             app:expandedTitleMarginBottom="70dp"
             app:expandedTitleMarginEnd="64dp"
             app:expandedTitleMarginStart="48dp"
+            app:expandedTitleTextAppearance="@style/AppTheme.TransparentText"
             app:contentScrim="?attr/colorPrimary"
             app:layout_scrollFlags="exitUntilCollapsed">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/app_name"
+                android:textColor="@android:color/white"
+                android:layout_marginRight="48dp"
+                android:layout_marginLeft="48dp"
+                android:textAlignment="gravity"
+                android:textSize="@dimen/abc_text_size_display_1_material"
+                app:layout_collapseMode="parallax"
+                android:layout_gravity="bottom"
+                android:layout_marginBottom="64dp" />
 
             <TextView
                 android:id="@+id/toolbar_subtitle"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -17,4 +17,8 @@
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
+
+    <style name="AppTheme.TransparentText" parent="@android:style/TextAppearance">
+        <item name="android:textColor">#00666666</item>
+    </style>
 </resources>


### PR DESCRIPTION
The title `Beta Updater for WhatsApp` is quite long, so the text is clipped:
![image](https://cloud.githubusercontent.com/assets/73690/12657917/23055074-c606-11e5-8070-ada1d06e60d2.png)
This PR changes the layout so wrapping is possible:
![image](https://cloud.githubusercontent.com/assets/73690/12657938/3a01db3a-c606-11e5-842b-29a1fded7c94.png)

I searched the internet for how to wrap the title of a `CollapsingToolbarLayout`. Unfortunately, that's not possible. Instead you have to make the `CollapsingToolbarLayout`'s title transparent and add another `TextView`.

I'm not an Android developer. In fact, I just downloaded Android Studio just to fix this (the cutoff title always annoyed me). So there might be a better to achieve this, and there might be layout issue when changing the display dimensions. Anyway, I wouldn't be offended if you'd reject this PR :wink: 

I really appreciate your project.